### PR TITLE
Add Q-learning baseline

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -4,13 +4,14 @@ from tqdm import tqdm
 
 from t_maze_env import TMazeEnv
 from agent_models import ActiveInferenceAgent
+from new_rl_agent import QLearningAgent
 
 
-def run_experiment(noise_levels, num_trials=500):
+def run_experiment(noise_levels, agent_cls, num_trials=500):
     histories = {}
     for noise in noise_levels:
         env = TMazeEnv(noise_level=noise)
-        agent = ActiveInferenceAgent(env)
+        agent = agent_cls(env)
         successes = []
         history = []
         for _ in tqdm(range(num_trials), desc=f"Noise {noise}"):
@@ -18,10 +19,19 @@ def run_experiment(noise_levels, num_trials=500):
             agent.reset()
             done = False
             while not done:
-                agent.infer_states(obs)
-                agent.learn(obs)
-                action = agent.select_action()
-                obs, reward, done = env.step(action)
+                if isinstance(agent, QLearningAgent):
+                    agent.update_context(obs)
+                    state = agent.get_state()
+                    action = agent.select_action(state)
+                    obs, reward, done = env.step(action)
+                    agent.update_context(obs)
+                    next_state = agent.get_state()
+                    agent.update(state, action, reward, next_state, done)
+                else:
+                    agent.infer_states(obs)
+                    agent.learn(obs)
+                    action = agent.select_action()
+                    obs, reward, done = env.step(action)
             successes.append(1 if reward > 0 else 0)
             history.append(np.mean(successes))
         histories[noise] = history
@@ -29,12 +39,28 @@ def run_experiment(noise_levels, num_trials=500):
 
 
 if __name__ == "__main__":
-    noise_levels = [0.1, 0.2, 0.3,0.4, 0.5]
-    histories = run_experiment(noise_levels)
-    x = np.arange(len(next(iter(histories.values()))))
+    noise_levels = [0.1, 0.2, 0.3, 0.4, 0.5]
+
+    # Active Inference agent
+    ai_hist = run_experiment(noise_levels, ActiveInferenceAgent)
+    x = np.arange(len(next(iter(ai_hist.values()))))
     plt.figure(figsize=(8, 5))
-    for noise, hist in histories.items():
-        plt.plot(x, hist, label=f"Noise {noise}")
+    for noise, hist in ai_hist.items():
+        plt.plot(x, hist, label=f"AI Noise {noise}")
+    plt.xlabel("Trial")
+    plt.ylabel("Cumulative Success Rate")
+    plt.ylim(0, 1)
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+    # Q-learning agent
+    rl_hist = run_experiment(noise_levels, QLearningAgent)
+    x = np.arange(len(next(iter(rl_hist.values()))))
+    plt.figure(figsize=(8, 5))
+    for noise, hist in rl_hist.items():
+        plt.plot(x, hist, label=f"QL Noise {noise}")
     plt.xlabel("Trial")
     plt.ylabel("Cumulative Success Rate")
     plt.ylim(0, 1)


### PR DESCRIPTION
## Summary
- implement a small Q-learning agent
- modify `simulation.py` so experiments can be run with Active Inference or Q-learning

## Testing
- `python simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_6878fa7a0f4c8330bc2616259b1d7d95