### PR TITLE
Fix RL cue handling and revert to simple TMaze

### DIFF
--- a/rl_agent.py
+++ b/rl_agent.py
@@ -22,8 +22,6 @@ class QLearningAgent:
         self.epsilon = self.epsilon_start
 
         self.context_est = 0  # 0: unknown, 1: left, 2: right
-        # cue is always presented at position 1 in TMazeEnv
-        self.cue_pos = getattr(self.env, "cue_pos", 1)
 
     def reset(self):
         """Reset internal state at the start of each trial."""
@@ -34,9 +32,8 @@ class QLearningAgent:
         return self.env.pos * 3 + self.context_est
 
     def update_context(self, obs):
-        o_pos = obs // self.num_cues
         o_cue = obs % self.num_cues
-        if o_pos == self.cue_pos and o_cue in (1, 2):
+        if o_cue in (1, 2):
             self.context_est = o_cue
 
     def select_action(self, state):

--- a/simulation.py
+++ b/simulation.py
@@ -7,14 +7,13 @@ from aci_agent import ActiveInferenceAgent
 from rl_agent import QLearningAgent
 
 
-def run_experiment(noise_levels, agent_cls, num_trials=500):
-    histories = {}
+def run_experiment(noise_levels, agent_cls, env_cls, num_trials=500):
+    acc = {}
     for noise in noise_levels:
-        env = TMazeEnv(noise_level=noise)
+        env = env_cls(noise_level=noise)
         agent = agent_cls(env)
-        successes = []
-        history = []
-        for _ in tqdm(range(num_trials), desc=f"Noise {noise}"):
+        successes = 0
+        for _ in tqdm(range(num_trials), desc=f"{agent_cls.__name__} Noise {noise}"):
             obs = env.reset()
             agent.reset()
             done = False
@@ -32,40 +31,33 @@ def run_experiment(noise_levels, agent_cls, num_trials=500):
                     agent.learn(obs)
                     action = agent.select_action()
                     obs, reward, done = env.step(action)
-            successes.append(1 if reward > 0 else 0)
-            history.append(np.mean(successes))
-        histories[noise] = history
-    return histories
+            if reward > 0:
+                successes += 1
+        acc[noise] = successes / num_trials
+    return acc
 
 
 if __name__ == "__main__":
     noise_levels = [0.3, 0.4, 0.5, 0.6, 0.7]
 
-    # Active Inference agent
-    ai_hist = run_experiment(noise_levels, ActiveInferenceAgent)
-    x = np.arange(len(next(iter(ai_hist.values()))))
+    ai_acc = run_experiment(noise_levels, ActiveInferenceAgent, TMazeEnv)
+    rl_acc = run_experiment(noise_levels, QLearningAgent, TMazeEnv)
+
+    x = np.arange(len(noise_levels))
+    width = 0.35
     plt.figure(figsize=(8, 5))
-    for noise, hist in ai_hist.items():
-        plt.plot(x, hist, label=f"AI Noise {noise}")
-    plt.xlabel("Trial")
-    plt.ylabel("Cumulative Success Rate")
+    plt.bar(x - width / 2, [ai_acc[n] for n in noise_levels], width, label="Active Inference")
+    plt.bar(x + width / 2, [rl_acc[n] for n in noise_levels], width, label="Q-Learning")
+    plt.xticks(x, [str(n) for n in noise_levels])
+    plt.xlabel("Noise Level")
+    plt.ylabel("Accuracy")
     plt.ylim(0, 1)
     plt.legend()
-    plt.grid(True)
     plt.tight_layout()
     plt.show()
 
-    # Q-learning agent
-    rl_hist = run_experiment(noise_levels, QLearningAgent)
-    x = np.arange(len(next(iter(rl_hist.values()))))
-    plt.figure(figsize=(8, 5))
-    for noise, hist in rl_hist.items():
-        plt.plot(x, hist, label=f"QL Noise {noise}")
-    plt.xlabel("Trial")
-    plt.ylabel("Cumulative Success Rate")
-    plt.ylim(0, 1)
-    plt.legend()
-    plt.grid(True)
-    plt.tight_layout()
-    plt.show()
+    base = noise_levels[0]
+    ai_drop = 100 * (ai_acc[base] - np.mean([ai_acc[n] for n in noise_levels[1:]])) / ai_acc[base]
+    rl_drop = 100 * (rl_acc[base] - np.mean([rl_acc[n] for n in noise_levels[1:]])) / rl_acc[base]
+    print(f"Average accuracy drop from noise {base}: AI {ai_drop:.1f}% | RL {rl_drop:.1f}%")
 


### PR DESCRIPTION
## Summary
- remove direct cue location access from `QLearningAgent`
- revert `simulation.py` to use the basic `TMazeEnv`

## Testing
- `python -m py_compile t_maze_env.py rl_agent.py simulation.py aci_agent.py`
- `python simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_687a312dafbc83308c32024995fd146f